### PR TITLE
Added initial folder structure

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,3 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import App from "./src/screens/App";
 
-export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Hello world!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+export default App;

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Please note, that being on the same network is crucial if you want to use a phon
 
 The Expo application will display a url and a QR code, that can be scanned, to access the compiled version.
 
+## Structure
+
+The application is structured as follows in regards to folders:
+
+- `assets` - contains all assets, such as images, fonts, etc.
+- `src` - contains all source code
+  - `components` - contains all components
+    - `atoms` - contains all atoms - Most Generic UI elements Completely reusable components
+    - `molecules` - contains all molecules - Specific components built with atoms
+  - `screens` - contains all screens - High level pages/screens/components/, not intended for reusability
+  - `utils` - contains all utilities, such as API calls, etc.
+
 ## Technology
 
 The following tech stack is used:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "mobile-dev",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/src/components/atoms/.gitkeep
+++ b/src/components/atoms/.gitkeep
@@ -1,0 +1,2 @@
+# Low Level Native Component Wrappers /
+# Most Generic UI elements Completely reusable

--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Text as NativeText } from "react-native";
+
+type TextProps = {
+    children: string;
+}
+
+export const Text = (props: TextProps) => {
+    return (
+        <NativeText>
+            {props.children}
+        </NativeText>
+    );
+}

--- a/src/components/molecules/.gitkeep
+++ b/src/components/molecules/.gitkeep
@@ -1,0 +1,2 @@
+# Specific components built with atoms/
+# may or may not be reusable

--- a/src/screens/.gitignore
+++ b/src/screens/.gitignore
@@ -1,0 +1,2 @@
+# High level pages/screens/components/
+# Not intended for reusability

--- a/src/screens/App.tsx
+++ b/src/screens/App.tsx
@@ -1,0 +1,21 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, View } from 'react-native';
+import { Text } from '../components/atoms/Text';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Hello world!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/utils/.gitkeep
+++ b/src/utils/.gitkeep
@@ -1,0 +1,1 @@
+# contains all utilities, such as API calls, etc.


### PR DESCRIPTION
Added initial folder structure, with allocated folders for components and screens.

Please note, that this solves #1

Inspiration taken from https://www.waldo.com/blog/react-native-project-structure

Documentation about the folders meaning has been added in the README.