### PR TITLE
Add `id`, `created_at` and `updated_at` to data models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "18.2.0",
         "react-native": "0.72.5",
         "react-native-pager-view": "6.2.0",
-        "react-native-screens": "~3.22.0",
+        "react-native-screens": "^3.25.0",
         "react-native-tab-view": "^3.5.2",
         "react-native-web": "~0.19.6",
         "zod": "^3.22.4"
@@ -14976,9 +14976,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.22.1.tgz",
-      "integrity": "sha512-ffzwUdVKf+iLqhWSzN5DXBm0s2w5sN0P+TaHHPAx42LT7+DT0g8PkHT1QDvxpR5vCEPSS1i3EswyVK4HCuhTYg==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.25.0.tgz",
+      "integrity": "sha512-TSC2Ad0hh763I8QT6XxMsPXAagQ+RawDSdFtKRvIz9fCYr96AjRwwaqmYivbqlDywOgcRBkIVynkFtp0ThmlYw==",
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"

--- a/src/components/molecules/CarsContext.tsx
+++ b/src/components/molecules/CarsContext.tsx
@@ -2,17 +2,32 @@ import React, { useEffect } from "react";
 import { Car } from "../../utils/types/Car";
 import fetchCars from "../../utils/Api/fetchCars";
 
+/**
+ * CarsState
+ * 
+ * This holds the cars, the error and the loading state.
+ */
 export interface CarsState {
     cars: Car[];
     error: false | string;
     loading: boolean;
 }
 
+/**
+ * CarsContextType
+ * 
+ * The type of the context.
+ */
 export interface CarsContextType {
     state: CarsState;
     setState: React.Dispatch<React.SetStateAction<CarsState>>;
 }
 
+/**
+ * CarsContext
+ * 
+ * The context that holds the cars state and the setState function.
+ */
 export const CarsContext = React.createContext<CarsContextType>({
     state: {
         cars: [],
@@ -22,10 +37,24 @@ export const CarsContext = React.createContext<CarsContextType>({
     setState: () => { },
 });
 
+/**
+ * CarsProviderProps
+ * 
+ * Props for the CarsProvider component.
+ */
 interface CarsProviderProps {
     children: React.ReactNode;
 }
 
+/**
+ * CarsProvider
+ * 
+ * Provider for the CarsContext. It sets the initial state and fetches the cars from the API.
+ * This have to wrap all the components that need to access the cars state.
+ * 
+ * @param {React.ReactNode} children
+ * @returns {React.ReactNode}
+ */
 export const CarsProvider = ({ children }: CarsProviderProps) => {
     const [state, setState] = React.useState<CarsState>({
         cars: [],

--- a/src/utils/Api/fetchCars.ts
+++ b/src/utils/Api/fetchCars.ts
@@ -45,6 +45,7 @@ export default async function fetchCars(state: CarsState, setState: React.Dispat
             error: `Error: Invalid response body: ${parsedCars.error.message}`,
             loading: false,
         });
+        console.error(parsedCars.error);
         return;
     }
     

--- a/src/utils/types/Booking.ts
+++ b/src/utils/types/Booking.ts
@@ -12,7 +12,7 @@ export type Booking = z.infer<typeof BookingSchema>;
  * Zod schema for a Booking
  */
 export const BookingSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     /** Which car the customer has ordered */
     car: CarSchema,
     startTime: z.coerce.date(),

--- a/src/utils/types/Booking.ts
+++ b/src/utils/types/Booking.ts
@@ -12,6 +12,7 @@ export type Booking = z.infer<typeof BookingSchema>;
  * Zod schema for a Booking
  */
 export const BookingSchema = z.object({
+    id: z.number(),
     /** Which car the customer has ordered */
     car: CarSchema,
     startTime: z.coerce.date(),
@@ -22,4 +23,6 @@ export const BookingSchema = z.object({
     endLocation: LocationSchema,
     price: z.number(),
     customer: CustomerSchema,
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Brand.ts
+++ b/src/utils/types/Brand.ts
@@ -16,7 +16,7 @@ export type Brand = {
  * Zod schema for a Brand
  */
 export const BrandSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     name: z.string(),
     created_at: z.coerce.date(),
     updated_at: z.coerce.date(),

--- a/src/utils/types/Brand.ts
+++ b/src/utils/types/Brand.ts
@@ -16,5 +16,8 @@ export type Brand = {
  * Zod schema for a Brand
  */
 export const BrandSchema = z.object({
+    id: z.number(),
     name: z.string(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Car.ts
+++ b/src/utils/types/Car.ts
@@ -11,7 +11,7 @@ export type Car = z.infer<typeof CarSchema>;
  * Zod schema for a Car
  */
 export const CarSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     engine: EngineSchema,
     name: z.string(),
     pictures: z.array(PictureSchema),

--- a/src/utils/types/Car.ts
+++ b/src/utils/types/Car.ts
@@ -11,6 +11,7 @@ export type Car = z.infer<typeof CarSchema>;
  * Zod schema for a Car
  */
 export const CarSchema = z.object({
+    id: z.number(),
     engine: EngineSchema,
     name: z.string(),
     pictures: z.array(PictureSchema),
@@ -27,4 +28,6 @@ export const CarSchema = z.object({
     doorCount: z.number(),
     manufacturingYear: z.number(),
     topSpeed: z.number(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Customer.ts
+++ b/src/utils/types/Customer.ts
@@ -6,8 +6,11 @@ export type Customer = z.infer<typeof CustomerSchema>;
  * Zod schema for a Customer
  */
 export const CustomerSchema = z.object({
+    id: z.number(),
     name: z.string(),
     email: z.string(),
     password: z.string(),
     address: z.string(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Customer.ts
+++ b/src/utils/types/Customer.ts
@@ -6,7 +6,7 @@ export type Customer = z.infer<typeof CustomerSchema>;
  * Zod schema for a Customer
  */
 export const CustomerSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     name: z.string(),
     email: z.string(),
     password: z.string(),

--- a/src/utils/types/Engine.ts
+++ b/src/utils/types/Engine.ts
@@ -9,6 +9,7 @@ export type Engine = z.infer<typeof EngineSchema>;
  * Zod schema for an Engine
  */
 export const EngineSchema = z.object({
+    id: z.number(),
     /** The amount of horse power the engine has */
     horsePower: z.number(),
     /** The amount of cylinders the engine has */
@@ -17,4 +18,7 @@ export const EngineSchema = z.object({
     volume: z.number(),
     /** The maximum RPM of the engine */
     maxRPM: z.number(),
+    
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Engine.ts
+++ b/src/utils/types/Engine.ts
@@ -9,7 +9,7 @@ export type Engine = z.infer<typeof EngineSchema>;
  * Zod schema for an Engine
  */
 export const EngineSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     /** The amount of horse power the engine has */
     horsePower: z.number(),
     /** The amount of cylinders the engine has */

--- a/src/utils/types/Location.ts
+++ b/src/utils/types/Location.ts
@@ -6,6 +6,9 @@ export type Location = z.infer<typeof LocationSchema>;
  * Zod schema for a Location
  */
 export const LocationSchema = z.object({
+    id: z.number(),
     name: z.string(),
     address: z.string(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });

--- a/src/utils/types/Location.ts
+++ b/src/utils/types/Location.ts
@@ -6,7 +6,7 @@ export type Location = z.infer<typeof LocationSchema>;
  * Zod schema for a Location
  */
 export const LocationSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     name: z.string(),
     address: z.string(),
     created_at: z.coerce.date(),

--- a/src/utils/types/Picture.ts
+++ b/src/utils/types/Picture.ts
@@ -13,7 +13,7 @@ export type Picture = z.infer<typeof PictureSchema>;
  * Zod schema for a Picture
  */
 export const PictureSchema = z.object({
-    id: z.number(),
+    id: z.number().nonnegative(),
     /** A url to an external hosted image */
     srcUrl: z.string().url(),
     /** An alternate text, which describes the picture */

--- a/src/utils/types/Picture.ts
+++ b/src/utils/types/Picture.ts
@@ -13,8 +13,11 @@ export type Picture = z.infer<typeof PictureSchema>;
  * Zod schema for a Picture
  */
 export const PictureSchema = z.object({
+    id: z.number(),
     /** A url to an external hosted image */
     srcUrl: z.string().url(),
     /** An alternate text, which describes the picture */
     alt: z.string(),
+    created_at: z.coerce.date(),
+    updated_at: z.coerce.date(),
 });


### PR DESCRIPTION
This update updates the data models to now include `id`, `created_at` and `updated_at`.

This therefore solves #33.

Please note, that this is not a breaking change, as it is additive.