### PR TITLE
CarBrowser using image from API

### DIFF
--- a/src/screens/CarBrowser.tsx
+++ b/src/screens/CarBrowser.tsx
@@ -60,7 +60,7 @@ function listCars(props: CarBrowserProps, carsFound: Array<Car>) {
                     key={car.id}
                     carName={car.name}
                     carType={car.type}
-                    imageLocation={require("../../assets/carpic.png")}
+                    imageLocation={{ uri: car.pictures[0].srcUrl }}
                     onPress={() => {props.navigation.push('CarDetails', {carId: car.id})}}
                 />
             ))}


### PR DESCRIPTION
This updates the CarBrowser to use the image from the API and not the static image, it uses right now.

This closes issue #61 